### PR TITLE
Fix typo in heading for public statistics

### DIFF
--- a/app/templates/home/org.hbs
+++ b/app/templates/home/org.hbs
@@ -98,7 +98,7 @@
         </article>
       </div>
       <section>
-        <AuHeading @level="5" @skin="5">Publicate Statistieken</AuHeading>
+        <AuHeading @level="5" @skin="5">Publieke statistieken</AuHeading>
         <div class="au-u-1-1 au-o-grid au-o-grid--tiny au-u-padding-top-small">
 
           {{! Sessions }}


### PR DESCRIPTION
## Issue
In the data monitoring tool the following mix of English & Dutch is shown:

## Expected
Text to be shown in Dutch as “Publieke statistieken”.